### PR TITLE
fix: ensure start.bat continues after npm commands

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -9,9 +9,9 @@ set APPROVED=true
 set CREATED_AT=2025-08-04T10:18:45.759182
 
 REM Install dependencies if needed
-npm install
+call npm install
 
 REM Launch the Electron app
-npm start
+call npm start
 
 pause


### PR DESCRIPTION
## Summary
- call npm scripts in `start.bat` so the script continues after each command

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68931421af8483229d3a266871cc59a2