### PR TITLE
Add PyInstaller spec and build instructions

### DIFF
--- a/Jarvik.spec
+++ b/Jarvik.spec
@@ -1,0 +1,38 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['app/main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[('app/static', 'static')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='Jarvik',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
    ```  
    - Tím se nainstaluje `electron` a `electron-builder` definované v `package.json`.
 
-3. **Python a knihovny**  
-   - Ujistěte se, že máte Python 3 a pip (`python --version`, `pip --version`).  
-   - Nainstalujte Flask, Requests a python-dotenv:
+3. **Python a knihovny**
+   - Ujistěte se, že máte Python 3 a pip (`python --version`, `pip --version`).
+   - Nainstalujte závislosti projektu:
      ```bash
-     pip install flask requests python-dotenv
+     pip install -r requirements.txt
      ```
 
 4. **Ollama a modely**  
@@ -58,6 +58,21 @@
   npm run dist
   ```
   Vygeneruje se balíček podle nastavení `electron-builder`.
+
+## Jarvik.exe na Windows
+
+Chcete‑li spustit backend jako samostatnou aplikaci na Windows:
+
+1. V příkazovém řádku nainstalujte Python závislosti:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Vytvořte spustitelný soubor pomocí PyInstalleru:
+   ```bash
+   pyinstaller Jarvik.spec
+   ```
+   V adresáři `dist` se objeví `Jarvik.exe`.
+3. Před spuštěním nezapomeňte nastavit proměnné prostředí `API_KEY` a `USERNAME` a mít nainstalovaný [Ollama](https://ollama.com/) s potřebnými modely.
 
 ## Popis
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+requests
+python-dotenv
+pyinstaller


### PR DESCRIPTION
## Summary
- add `requirements.txt` with Python dependencies
- include `Jarvik.spec` for building a single-file backend executable
- document how to install dependencies and create `Jarvik.exe` on Windows

## Testing
- `python -m PyInstaller --onefile --name Jarvik --add-data app/static:static app/main.py`
- `python -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_b_68ad637e59d08322b02b59fc863c9772