### PR TITLE
Fix fetch body field names for ask endpoint

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -41,7 +41,12 @@
       const res = await fetch('/ask', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({ message, apiUrl, username, apiKey })
+        body: JSON.stringify({
+          message,
+          api_url: apiUrl,
+          username,
+          api_key: apiKey
+        })
       });
       const data = await res.json();
       document.getElementById('response').textContent = data.response || data.error;


### PR DESCRIPTION
## Summary
- Send `api_url` and `api_key` fields in JSON body to match server expectations

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python app/main.py` (followed by a curl POST to `/ask` including api_key and username which returns a 401 response rather than missing-field error)


------
https://chatgpt.com/codex/tasks/task_b_68ada0813ae8832288d35b1b318252d5