### PR TITLE
Handle missing models in ask endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -80,11 +80,14 @@ def ask():
         return jsonify(context_data), 401
 
     available_models = fetch_models()
+    if not available_models:
+        return jsonify({"error": "No models available"}), 503
+
     if requested_model and requested_model in available_models:
         model = requested_model
     else:
         model = choose_model(query)
-        if model not in available_models and available_models:
+        if model not in available_models:
             model = available_models[0]
     full_prompt = context_data.get("context", "") + "\n" + query
 


### PR DESCRIPTION
## Summary
- Return HTTP 503 with error message when no models are available
- Avoid calling ollama subprocess when model list is empty

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae8775aac0832292604f1d70be7b9e