### PR TITLE
refactor: avoid storing API key in localStorage

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -24,11 +24,12 @@
     const usernameInput = document.getElementById('username');
     const apiKeyInput = document.getElementById('apiKey');
     const modelSelect = document.getElementById('model');
+    // Holds the API key only for the current session
+    let sessionApiKey = '';
 
-    // Load previously saved values
+    // Load previously saved values (except API key)
     apiUrlInput.value = localStorage.getItem('apiUrl') || '';
     usernameInput.value = localStorage.getItem('username') || '';
-    apiKeyInput.value = localStorage.getItem('apiKey') || '';
 
     async function loadModels() {
       const res = await fetch('/models');
@@ -48,7 +49,7 @@
       // Persist inputs for future use
       localStorage.setItem('apiUrl', apiUrl);
       localStorage.setItem('username', username);
-      localStorage.setItem('apiKey', apiKey);
+      sessionApiKey = apiKey;
 
       const res = await fetch('/ask', {
         method: 'POST',
@@ -57,7 +58,7 @@
           message,
           api_url: apiUrl,
           username,
-          api_key: apiKey,
+          api_key: sessionApiKey,
           model
         })
       });


### PR DESCRIPTION
## Summary
- avoid storing API key in localStorage in the web UI
- keep API key only in a session variable for the current browser session

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `python -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_b_68ae8891ecac83228107ecd3e89c560b