### PR TITLE
Add cached context and code editing UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@ dist/
 __pycache__/
 .venv/
 
+# Cached context
+app/context_cache.json
+
 # Environment
 .env

--- a/app/fura_client.py
+++ b/app/fura_client.py
@@ -1,9 +1,41 @@
+import json
+import os
+import time
+
 import requests
 
 API_URL = "https://fura.jarvik-ai.tech"
+CACHE_FILE = os.path.join(os.path.dirname(__file__), "context_cache.json")
+CACHE_TTL = 60 * 60 * 24  # 24 hours
+
+
+def _load_cache():
+    if os.path.exists(CACHE_FILE):
+        try:
+            with open(CACHE_FILE, "r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _save_cache(cache):
+    try:
+        with open(CACHE_FILE, "w", encoding="utf-8") as fh:
+            json.dump(cache, fh)
+    except OSError:
+        pass
 
 
 def get_context(query, api_key, username, api_url: str = API_URL):
+    cache = _load_cache()
+    now = time.time()
+    cached = cache.get(query)
+    if cached and now - cached.get("timestamp", 0) < CACHE_TTL:
+        cached_data = cached.get("data")
+    else:
+        cached_data = None
+
     headers = {"Authorization": f"Bearer {api_key}"}
     data = {"query": query, "user": username}
     try:
@@ -14,10 +46,13 @@ def get_context(query, api_key, username, api_url: str = API_URL):
             timeout=10,
         )
         res.raise_for_status()
+        result = res.json()
+        cache[query] = {"timestamp": now, "data": result}
+        _save_cache(cache)
+        return result
     except requests.RequestException as exc:
+        if cached_data is not None:
+            return cached_data
         return {"error": "API request failed", "details": str(exc)}
-
-    try:
-        return res.json()
     except ValueError:
         return {"error": "Invalid JSON response", "details": res.text}

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -94,6 +94,32 @@
     .clear-btn {
       background: #8b2e2e;
     }
+
+    .code-dev {
+      margin-top: 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .code-dev textarea {
+      background: #2d333b;
+      border: 1px solid #3d8361;
+      color: #e1e1e1;
+      padding: 0.5rem;
+      width: 100%;
+      border-radius: 4px;
+    }
+
+    .code-dev button {
+      background: #3d8361;
+      border: none;
+      padding: 0.5rem 1rem;
+      border-radius: 4px;
+      color: #fff;
+      cursor: pointer;
+      align-self: flex-start;
+    }
   </style>
 </head>
 <body>
@@ -110,6 +136,13 @@
     <div class="input-area">
       <textarea id="query" rows="3" placeholder="Ask something..."></textarea>
       <button onclick="ask()">Send</button>
+    </div>
+    <div class="code-dev">
+      <h2>Code Development</h2>
+      <textarea id="originalCode" rows="10" placeholder="Original code..."></textarea>
+      <textarea id="codeInstruction" rows="3" placeholder="Request..."></textarea>
+      <button onclick="processCode()">Process</button>
+      <textarea id="resultCode" rows="10" placeholder="Resulting code..." readonly></textarea>
     </div>
   </div>
   <script>
@@ -186,6 +219,40 @@
       }
 
       appendMessage(data.response || data.error, 'bot');
+    }
+
+    async function processCode() {
+      const code = document.getElementById('originalCode').value;
+      const instruction = document.getElementById('codeInstruction').value;
+      const apiUrl = apiUrlInput.value;
+      const username = usernameInput.value;
+      const apiKey = apiKeyInput.value;
+      const model = modelSelect.value;
+
+      localStorage.setItem('apiUrl', apiUrl);
+      localStorage.setItem('username', username);
+      sessionApiKey = apiKey;
+
+      const res = await fetch('/code', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          code,
+          instruction,
+          api_url: apiUrl,
+          username,
+          api_key: sessionApiKey,
+          model
+        })
+      });
+
+      let data;
+      try {
+        data = await res.json();
+      } catch (err) {
+        data = {error: 'Invalid server response'};
+      }
+      document.getElementById('resultCode').value = data.response || data.error;
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Cache context responses from the Fura API to allow limited offline usage
- Introduce `/code` endpoint and frontend UI for transforming source code based on user requests
- Ignore generated context cache file

## Testing
- `python -m py_compile app/main.py app/fura_client.py`


------
https://chatgpt.com/codex/tasks/task_b_68aeccdee14483228c8fb409d3823cd0