### PR TITLE
refactor: redesign UI layout and add code uploads

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -141,6 +141,7 @@ def code():
 
     source_code = data.get("code")
     instruction = data.get("instruction")
+    files = data.get("files") or {}
     api_key = data.get("api_key")
     username = data.get("username")
     api_url = data.get("api_url")
@@ -179,12 +180,17 @@ def code():
 
     context_text = context_data.get("context", "")
     debug_data = context_data.get("debug")
+    files_text = ""
+    for name, content in files.items():
+        files_text += f"\nFilename: {name}\n{content}\n"
+
     full_prompt = (
         context_text
         + "\nInstruction: "
         + instruction
         + "\n\nCode:\n"
         + source_code
+        + files_text
     )
     logger.info("Using model %s for code endpoint", model)
 

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -51,8 +51,23 @@
       cursor: pointer;
     }
 
-    .context-debug {
+    .qa-area {
       margin-top: 1rem;
+      display: flex;
+      gap: 1rem;
+    }
+
+    #chat {
+      border: 1px solid #3d8361;
+      padding: 1rem;
+      height: 300px;
+      overflow-y: auto;
+      background: #1e242b;
+      flex: 1;
+    }
+
+    .context-debug {
+      width: 250px;
       display: flex;
       flex-direction: column;
       gap: 0.5rem;
@@ -65,15 +80,7 @@
       padding: 0.5rem;
       width: 100%;
       border-radius: 4px;
-    }
-
-    #chat {
-      margin-top: 1rem;
-      border: 1px solid #3d8361;
-      padding: 1rem;
-      height: 300px;
-      overflow-y: auto;
-      background: #1e242b;
+      height: 100px;
     }
 
     .message {
@@ -155,17 +162,21 @@
       <p id="modelDesc" style="width:100%"></p>
       <button onclick="clearChat()" class="clear-btn">Clear chat</button>
     </div>
-    <div id="chat"></div>
-    <div class="context-debug">
-      <textarea id="context" rows="4" placeholder="Context..." readonly></textarea>
-      <textarea id="debug" rows="4" placeholder="Debug info..." readonly></textarea>
-    </div>
     <div class="input-area">
       <textarea id="query" rows="3" placeholder="Ask something..."></textarea>
       <button onclick="ask()">Send</button>
     </div>
-    <div class="code-dev">
+    <div class="qa-area">
+      <div id="chat"></div>
+      <div class="context-debug">
+        <textarea id="context" placeholder="Context..." readonly></textarea>
+        <textarea id="debug" placeholder="Debug info..." readonly></textarea>
+      </div>
+    </div>
+    <button id="toggleDev" onclick="toggleDevUI()">Toggle Development UI</button>
+    <div class="code-dev" id="devUI" style="display:none;">
       <h2>Code Development</h2>
+      <input type="file" id="codeFiles" multiple />
       <textarea id="originalCode" rows="10" placeholder="Original code..."></textarea>
       <textarea id="codeInstruction" rows="3" placeholder="Request..."></textarea>
       <button onclick="processCode()">Process</button>
@@ -184,6 +195,7 @@
     const chatDiv = document.getElementById('chat');
     const loginBtn = document.getElementById('loginBtn');
     const logoutBtn = document.getElementById('logoutBtn');
+    const codeFilesInput = document.getElementById('codeFiles');
 
     let sessionApiKey = localStorage.getItem('apiKey') || '';
 
@@ -319,12 +331,18 @@
       const model = modelSelect.value;
       const memory = memorySelect.value;
 
+      const files = {};
+      for (const file of codeFilesInput.files) {
+        files[file.name] = await file.text();
+      }
+
       const res = await fetch('/code', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({
           code,
           instruction,
+          files,
           api_url: apiUrl,
           username,
           api_key: apiKey,
@@ -342,6 +360,11 @@
       document.getElementById('resultCode').value = data.response || data.error;
       contextArea.value = data.context || '';
       debugArea.value = data.debug ? JSON.stringify(data.debug, null, 2) : '';
+    }
+
+    function toggleDevUI() {
+      const dev = document.getElementById('devUI');
+      dev.style.display = dev.style.display === 'none' ? '' : 'none';
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- place query field above scrollable answer area and move debug/context to side
- add toggleable development UI with file upload support
- extend backend to include uploaded code files in prompts

## Testing
- `python -m py_compile app/main.py`
- `python -m py_compile app/fura_client.py`


------
https://chatgpt.com/codex/tasks/task_b_68af510eff8c832281fdb99c536531b8