### PR TITLE
Handle subprocess output encoding

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,8 @@ def fetch_models():
             capture_output=True,
             text=True,
             check=True,
+            encoding="utf-8",
+            errors="replace",
         )
 
         models = []
@@ -134,6 +136,8 @@ def ask():
             capture_output=True,
             check=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=60,
         )
         logger.info("Model %s responded successfully", model)
@@ -222,6 +226,8 @@ def code():
             capture_output=True,
             check=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=60,
         )
         logger.info("Model %s responded successfully", model)


### PR DESCRIPTION
## Summary
- handle UnicodeDecodeError by explicitly using UTF-8 decoding with replacement when running Ollama commands

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_b_68af64956b3c8322a60d68eb14dbb1f7