### PR TITLE
Add remember toggle and forward login user to Fura

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -111,7 +111,7 @@ class JarvikCLI(cmd.Cmd):
             "username": self.username,
             "api_key": self.api_key,
             "model": self.model or None,
-            "memory": self.memory,
+            "remember": self.memory == "public",
         }
         try:
             res = requests.post(f"{BASE_URL}/ask", json=payload, timeout=120)
@@ -157,7 +157,7 @@ class JarvikCLI(cmd.Cmd):
             "username": self.username,
             "api_key": self.api_key,
             "model": self.model or None,
-            "memory": self.memory,
+            "remember": self.memory == "public",
         }
         try:
             res = requests.post(f"{BASE_URL}/code", json=payload, timeout=120)

--- a/app/fura_client.py
+++ b/app/fura_client.py
@@ -27,7 +27,7 @@ def _save_cache(cache):
         pass
 
 
-def get_context(query, api_key, username, api_url: str = API_URL, memory: str = "private"):
+def get_context(query, api_key, username, api_url: str = API_URL, remember: bool = False):
     cache = _load_cache()
     now = time.time()
     cached = cache.get(query)
@@ -37,7 +37,7 @@ def get_context(query, api_key, username, api_url: str = API_URL, memory: str = 
         cached_data = None
 
     headers = {"Authorization": f"Bearer {api_key}"}
-    data = {"query": query, "user": username, "public": memory == "public"}
+    data = {"query": query, "user": username, "remember": remember}
     try:
         res = requests.post(
             f"{api_url}/get_context",

--- a/app/main.py
+++ b/app/main.py
@@ -108,7 +108,7 @@ def ask():
     username = data.get("username")
     api_key = data.get("api_key")
     requested_model = data.get("model")
-    memory = data.get("memory", "private")
+    remember = data.get("remember", False)
 
     errors = _validate_fura_fields(message, api_url, username, api_key)
     if errors:
@@ -118,7 +118,7 @@ def ask():
     query = message
     logger.info("Received ask request for model %s", requested_model)
 
-    context_data = get_context(query, api_key, username, api_url, memory)
+    context_data = get_context(query, api_key, username, api_url, remember)
 
     if "error" in context_data:
         logger.error("Context retrieval failed: %s", context_data.get("error"))
@@ -182,7 +182,7 @@ def code():
     username = data.get("username")
     api_url = data.get("api_url")
     requested_model = data.get("model")
-    memory = data.get("memory", "private")
+    remember = data.get("remember", False)
 
     logger.info("Received code request for model %s", requested_model)
 
@@ -194,9 +194,9 @@ def code():
         return jsonify({"error": "Missing code or instruction"}), 400
 
     if api_url:
-        context_data = get_context(instruction, api_key, username, api_url, memory)
+        context_data = get_context(instruction, api_key, username, api_url, remember)
     else:
-        context_data = get_context(instruction, api_key, username, memory=memory)
+        context_data = get_context(instruction, api_key, username, remember=remember)
 
     if "error" in context_data:
         logger.error("Context retrieval failed: %s", context_data.get("error"))

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -155,9 +155,9 @@
       <button id="loginBtn" onclick="login()">Login</button>
       <button id="logoutBtn" onclick="logout()">Logout</button>
       <select id="model"></select>
-      <select id="memory">
-        <option value="private">Private memory</option>
-        <option value="public">Public memory</option>
+      <select id="remember">
+        <option value="false">Private memory</option>
+        <option value="true">Public memory</option>
       </select>
       <p id="modelDesc" style="width:100%"></p>
       <button onclick="clearChat()" class="clear-btn">Clear chat</button>
@@ -188,7 +188,7 @@
     const usernameInput = document.getElementById('username');
     const apiKeyInput = document.getElementById('apiKey');
     const modelSelect = document.getElementById('model');
-    const memorySelect = document.getElementById('memory');
+    const rememberSelect = document.getElementById('remember');
     const modelDesc = document.getElementById('modelDesc');
     const contextArea = document.getElementById('context');
     const debugArea = document.getElementById('debug');
@@ -295,7 +295,7 @@
       const username = usernameInput.value;
       const apiKey = sessionApiKey;
       const model = modelSelect.value;
-      const memory = memorySelect.value;
+      const remember = rememberSelect.value === 'true';
 
       appendMessage(message, 'user');
       document.getElementById('query').value = '';
@@ -311,7 +311,7 @@
           username,
           api_key: apiKey,
           model,
-          memory
+          remember
         })
       });
 
@@ -343,7 +343,7 @@
       const username = usernameInput.value;
       const apiKey = sessionApiKey;
       const model = modelSelect.value;
-      const memory = memorySelect.value;
+      const remember = rememberSelect.value === 'true';
 
       const files = {};
       for (const file of codeFilesInput.files) {
@@ -363,7 +363,7 @@
           username,
           api_key: apiKey,
           model,
-          memory
+          remember
         })
       });
 


### PR DESCRIPTION
## Summary
- Bind Private memory toggle to boolean `remember` and send with chat/code requests
- Forward `username` as `user` along with `remember` when retrieving context
- Update CLI to support new `remember` flag

## Testing
- `python -m py_compile app/main.py app/fura_client.py app/cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b07e81144c8322823e837f50a7f76c