### PR TITLE
Verify credentials with auth endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -87,6 +87,29 @@ def simple():
 def models():
     return jsonify(fetch_models())
 
+
+@app.route("/auth/me", methods=["POST"])
+def auth_me():
+    data = request.get_json() or {}
+    api_url = data.get("api_url")
+    username = data.get("username")
+    api_key = data.get("api_key")
+
+    if not api_url or not username or not api_key:
+        return jsonify({"error": "Missing api_url, username or api_key"}), 400
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    params = {"user": username}
+
+    try:
+        res = requests.get(f"{api_url}/auth/me", headers=headers, params=params, timeout=10)
+        if res.ok:
+            return jsonify(res.json())
+        return jsonify(res.json()), res.status_code
+    except requests.RequestException as exc:
+        logger.error("Auth check failed: %s", exc)
+        return jsonify({"error": "Auth check failed", "details": str(exc)}), 502
+
 def _validate_fura_fields(message, api_url, username, api_key):
     """Ensure required fields for the Fura request are non-empty strings."""
     errors = {}

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -245,7 +245,7 @@
       logoutBtn.style.display = loggedIn ? '' : 'none';
     }
 
-    function login() {
+    async function login() {
       const apiUrl = apiUrlInput.value;
       const username = usernameInput.value;
       const apiKey = apiKeyInput.value;
@@ -253,11 +253,40 @@
         alert('Username and API Key are required');
         return;
       }
-      localStorage.setItem('apiUrl', apiUrl);
-      localStorage.setItem('username', username);
-      localStorage.setItem('apiKey', apiKey);
-      sessionApiKey = apiKey;
-      updateAuthUI();
+
+      try {
+        const res = await fetch('/auth/me', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ api_url: apiUrl, username, api_key: apiKey })
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || data.error) {
+          alert('Login failed');
+          appendMessage('Login failed', 'bot');
+          sessionApiKey = '';
+          localStorage.removeItem('apiUrl');
+          localStorage.removeItem('username');
+          localStorage.removeItem('apiKey');
+          updateAuthUI();
+          return;
+        }
+        alert('Login successful');
+        appendMessage('Login successful', 'bot');
+        localStorage.setItem('apiUrl', apiUrl);
+        localStorage.setItem('username', username);
+        localStorage.setItem('apiKey', apiKey);
+        sessionApiKey = apiKey;
+        updateAuthUI();
+      } catch (err) {
+        alert('Login failed');
+        appendMessage('Login failed', 'bot');
+        sessionApiKey = '';
+        localStorage.removeItem('apiUrl');
+        localStorage.removeItem('username');
+        localStorage.removeItem('apiKey');
+        updateAuthUI();
+      }
     }
 
     function logout() {


### PR DESCRIPTION
## Summary
- add `/auth/me` route that checks credentials against remote API
- update login flow to call `/auth/me` and persist only on success

## Testing
- `python -m py_compile app/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b087b1e94c8322961660b9ff893765