### PR TITLE
Reduce cache pruning memory footprint

### DIFF
--- a/app/fura_client.py
+++ b/app/fura_client.py
@@ -1,6 +1,7 @@
 import os
 import time
 import shelve
+import heapq
 
 import requests
 
@@ -19,8 +20,12 @@ def _prune_cache(cache):
     excess = len(cache) - CACHE_MAX_ITEMS
     if excess <= 0:
         return
-    sorted_items = sorted(cache.items(), key=lambda item: item[1].get("timestamp", 0))
-    for key, _ in sorted_items[:excess]:
+    oldest = heapq.nsmallest(
+        excess,
+        cache.items(),
+        key=lambda item: item[1].get("timestamp", 0),
+    )
+    for key, _ in oldest:
         del cache[key]
 
 


### PR DESCRIPTION
## Summary
- Optimize cache eviction to avoid sorting entire cache
- Import heapq for memory-efficient pruning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b2137e037c8322ba228c2b798297d6